### PR TITLE
cmake: Compile libsamplerate with -fPIC on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ if(USE_ERIKD_LIBSAMPLERATE_DEPS)
 	set(LIBSAMPLERATE_INSTALL_PKGCONFIG_MODULE OFF)
 	option(BUILD_TESTING "" OFF) # ON by default in CTest
 	add_subdirectory(deps/libsamplerate)
+	if (OS_LINUX)
+		set_target_properties(samplerate PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+	endif()
 	target_link_libraries(${PROJECT_NAME}
 		samplerate
 	)


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Set `POSITION_INDEPENDENT_CODE` when building `libsamplerate` on Linux.

Prior to this PR, I have never build the plugin with statically linking libsamplerate.
When writing a comment for #15, I realized the static-link requires `-fPIC` to successfully build the plugin.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Build has succeeded on Fedora 41.

I have not tested the built binary can be loaded by obs-studio.

If the user of #15 want further study to make this plugin working with Flatpak, I will test this PR.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
